### PR TITLE
Fixed intermittent crashes in fullscreen zooming

### DIFF
--- a/UIPhotoGallery/UIPhotoGalleryView.m
+++ b/UIPhotoGallery/UIPhotoGalleryView.m
@@ -169,7 +169,7 @@
         currentPage = (NSInteger)newPage;
         [self populateSubviews];
         
-        for (UIPhotoContainerView *subView in reusableViews) {
+        for (UIPhotoContainerView *subView in [reusableViews copy]) {
             if (subView.tag != newPage) {
                 [subView resetZoom];
             }


### PR DESCRIPTION
When zooming in and out multiple times quickly on an image in
fullscreen mode, the example application crashes intermittently.
stops at line:
"for (UIPhotoContainerView *subView in reusableViews) {" from
"UIPhotoGalleryView.m"

breakpoint analyzer:
#0 0x38dd9cc0 in objc_exception_throw ()
#1 0x2e4c99f0 in __NSFastEnumerationMutationHandler ()
#2 0x0009d61c in -[UIPhotoGalleryView scrollViewDidScroll:] at

UIPhotoGallery/UIPhotoGalleryView.m:172
#3 0x311026e4 in -UIScrollView(UIScrollViewInternal) _notifyDidScroll
