### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To declare a caption component in specific index:
 - (UIView*)photoGallery:(UIPhotoGalleryView*)photoGallery customViewCaptionAtIndex:(NSInteger)index;
 ```
 
-Similar to view component, **only one** caption contruction method is used at a moment to contruct caption for gallery item, depends on `UIPhotoGalleryView`'s `captionStyle`, including 3 supported styles:
+Similar to view component, **only one** caption construction method is used at a moment to contruct caption for gallery item, depends on `UIPhotoGalleryView`'s `captionStyle`, including 3 supported styles:
 
 ```objective-c
 UIPhotoCaptionStylePlainText


### PR DESCRIPTION
@ethan605, I've corrected a typographical error in the documentation of the [UIPhotoGallery](https://github.com/ethan605/UIPhotoGallery) project. Specifically, I've changed contruction to construction. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
